### PR TITLE
Update dependencies to support Java 11 development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.fenixedu</groupId>
         <artifactId>web-app-project</artifactId>
-        <version>2.5.2</version>
+        <version>2.6.0</version>
         <relativePath />
     </parent>
 
@@ -40,7 +40,8 @@
         <version.org.fenixedu.spaces>3.0.0</version.org.fenixedu.spaces>
         <version.pt.ist.a3es-ist>4.0.0</version.pt.ist.a3es-ist>
         <version.pt.ist.digitalized-signatures>4.0.1</version.pt.ist.digitalized-signatures>
-        <version.pt.ist.fenixedu-ist-bpi>2.1.4</version.pt.ist.fenixedu-ist-bpi>
+        <!-- <version.pt.ist.fenixedu-ist-bpi>2.1.4</version.pt.ist.fenixedu-ist-bpi> -->
+        <version.pt.ist.fenixedu-ist-bpi>2.2.0-SNAPSHOT</version.pt.ist.fenixedu-ist-bpi>
         <version.pt.ist.fenixedu-ist-sas-integration>2.0.0</version.pt.ist.fenixedu-ist-sas-integration>
         <version.org.apache.poi>3.17</version.org.apache.poi>
         <version.pt.ist.fenixedu-ulisboa-cgdIntegration>3.0.0</version.pt.ist.fenixedu-ulisboa-cgdIntegration>
@@ -71,6 +72,8 @@
                     <fork>true</fork>
                     <maxmem>2048</maxmem>
                     <meminitial>1024</meminitial>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -82,6 +85,17 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-rt</artifactId>
+            <version>2.3.2</version>
+            <!-- <type>pom</type> -->
+        </dependency>
         <dependency>
             <groupId>org.fenixedu</groupId>
             <artifactId>fenixedu-academic</artifactId>


### PR DESCRIPTION
This is blocked by https://github.com/ist-dsi/fenixedu-ist-bpi/pull/8 since we need a higher Tomcat version to run the webapp on Java 11.